### PR TITLE
Add awtSCADA to IEC-61850 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ Currently, there are **75 protocols** with a total of 400 resources.
 - [Fuzz Testing IEC 61850](https://www.youtube.com/watch?v=QehBHZyy4W4) - Markus Mahrla @ CS3STHLM 2019
 ### Tools
 - [libiec61850](https://github.com/mz-automation/libiec61850) - Open-source library for the IEC 61850 protocols
-- [awtSCADA](https://github.com/larionovavi-stack/bitscada) - Browser-based SCADA/HMI with full IEC 61850 MMS/GOOSE/SV stack, runs from a single HTML file
+- [awtSCADA](https://github.com/larionovavi-stack/awtscada) - Browser-based SCADA/HMI with full IEC 61850 MMS/GOOSE/SV stack, runs from a single HTML file
 
 
 ## IEEE-C37.118

--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ Currently, there are **75 protocols** with a total of 400 resources.
 - [Fuzz Testing IEC 61850](https://www.youtube.com/watch?v=QehBHZyy4W4) - Markus Mahrla @ CS3STHLM 2019
 ### Tools
 - [libiec61850](https://github.com/mz-automation/libiec61850) - Open-source library for the IEC 61850 protocols
+- [BitSCADA](https://github.com/larionovavi-stack/bitscada) - Browser-based SCADA/HMI with full IEC 61850 MMS/GOOSE/SV stack, runs from a single HTML file
 
 
 ## IEEE-C37.118

--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ Currently, there are **75 protocols** with a total of 400 resources.
 - [Fuzz Testing IEC 61850](https://www.youtube.com/watch?v=QehBHZyy4W4) - Markus Mahrla @ CS3STHLM 2019
 ### Tools
 - [libiec61850](https://github.com/mz-automation/libiec61850) - Open-source library for the IEC 61850 protocols
-- [BitSCADA](https://github.com/larionovavi-stack/bitscada) - Browser-based SCADA/HMI with full IEC 61850 MMS/GOOSE/SV stack, runs from a single HTML file
+- [awtSCADA](https://github.com/larionovavi-stack/bitscada) - Browser-based SCADA/HMI with full IEC 61850 MMS/GOOSE/SV stack, runs from a single HTML file
 
 
 ## IEEE-C37.118


### PR DESCRIPTION
## Addition

Added **[awtSCADA](https://github.com/larionovavi-stack/awtscada)** to the IEC-61850 Tools section.

awtSCADA is a browser-based SCADA/HMI with a full IEC 61850 MMS/GOOSE/SV stack that runs from a single HTML file. It includes a Python gateway for connecting to real IEC 61850 devices.

- Live Demo: https://larionovavi-stack.github.io/awtscada/
- Supports IEC 61850 MMS, GOOSE, and Sampled Values