### PR TITLE
Add aem-modbus-simulator to Modbus Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,7 @@ Currently, there are **75 protocols** with a total of 400 resources.
 - [Understanding SCADA's Modbus Protocol](https://www.youtube.com/watch?v=oVDYaG2HInU) - Justin Searle @ Black Hat Asia (2015)
 - [Unraveling SCADA Protocols Using Sulley Fuzzer](https://www.youtube.com/watch?v=UUta_Ord8GI) - Ganesh Devarajan @ DEF CON 15 (2014)
 ### Tools
+- [aem-modbus-simulator](https://github.com/leaberg69/aem-modbus-simulator) - Open-source Python Modbus RTU/TCP slave simulator with realistic 147-register industrial DC monitor map. Useful as a Modbus target for protocol research, fuzzing campaigns, and IDS rule validation without physical hardware.
 - [ctmodbus](https://github.com/ControlThings-io/ctmodbus) - A tool to interact with the Modbus protocol
 - [Malmod](https://github.com/mliras/malmod) - Scripts to attack Modicon M340 via UMAS
 - [mbtget](https://github.com/sourceperl/mbtget) - A simple Modbus/TCP client in Perl

--- a/protocols/modbus.md
+++ b/protocols/modbus.md
@@ -37,6 +37,7 @@
 - [Understanding SCADA's Modbus Protocol](https://www.youtube.com/watch?v=oVDYaG2HInU) - Justin Searle @ Black Hat Asia (2015)
 - [Unraveling SCADA Protocols Using Sulley Fuzzer](https://www.youtube.com/watch?v=UUta_Ord8GI) - Ganesh Devarajan @ DEF CON 15 (2014)
 ## Tools
+- [aem-modbus-simulator](https://github.com/leaberg69/aem-modbus-simulator) - Open-source Python Modbus RTU/TCP slave simulator with realistic 147-register industrial DC monitor map. Useful as a Modbus target for protocol research, fuzzing campaigns, and IDS rule validation without physical hardware.
 - [ctmodbus](https://github.com/ControlThings-io/ctmodbus) - A tool to interact with the Modbus protocol
 - [Malmod](https://github.com/mliras/malmod) - Scripts to attack Modicon M340 via UMAS
 - [mbtget](https://github.com/sourceperl/mbtget) - A simple Modbus/TCP client in Perl


### PR DESCRIPTION
## Summary

Adds [aem-modbus-simulator](https://github.com/leaberg69/aem-modbus-simulator) to the **Modbus > Tools** section (both `README.md` and `protocols/modbus.md`).

### What it is

Open-source Python Modbus RTU/TCP slave simulator that emulates a realistic industrial DC voltage monitor — 147 holding registers in 17 functional blocks, supports six baudrates (4,800-115,200 bps), TCP and Serial modes. MIT license, pymodbus 2.x/3.x compatible.

### Why it fits the Tools section

The current Tools list (ctmodbus, mbtget, PyModbus, Malmod) covers Modbus *clients/attackers*. This adds a complementary **server-side** tool — a configurable slave target useful for:

- **Protocol research:** test fuzzing tools against realistic register layouts (most public Modbus simulators have toy maps)
- **IDS/IPS rule validation:** generate normal vs. anomalous Modbus traffic deterministically
- **Honeypot development:** emulate real industrial devices with plausible register responses
- **SCADA pentest training:** practice attacks against a realistic Modbus target without physical hardware

### Format compliance

- Alphabetical order in Tools section ("aem..." before "ctmodbus")
- Updated both top-level README.md and protocols/modbus.md
- Matches existing entry format (markdown bullet + description)

### Disclosure

I work at LRI Automação Industrial (manufacturer of the AEM-60DC8 industrial DC monitor whose register map is mirrored in the simulator). The simulator itself is fully MIT-licensed open source; the Modbus register map is a public protocol interface anyway. Happy to reword the description if too marketing-toned.