### PR TITLE
Add modbus-server to Modbus tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,6 +907,7 @@ Currently, there are **75 protocols** with a total of 401 resources.
 - [ctmodbus](https://github.com/ControlThings-io/ctmodbus) - A tool to interact with the Modbus protocol
 - [Malmod](https://github.com/mliras/malmod) - Scripts to attack Modicon M340 via UMAS
 - [mbtget](https://github.com/sourceperl/mbtget) - A simple Modbus/TCP client in Perl
+- [modbus-server](https://github.com/cybcon/modbus-server) - Lightweight Python Modbus TCP/UDP slave simulator with Docker image, register persistence and Prometheus metrics endpoint
 - [PyModbus](https://github.com/pymodbus-dev/pymodbus) - A full modbus protocol written in python
 
 


### PR DESCRIPTION
This PR adds `modbus-server` to the Tools section under Modbus.

**What it is:**
A simple, Python-based Modbus TCP/UDP server (slave) for debugging and
simulation purposes. It allows predefining register values (coils,
discrete inputs, holding/input registers) via a JSON config file, making
it useful for testing Modbus masters/clients without real hardware.

**Why it's relevant:**
- Actively maintained (MIT licensed, 14 releases, latest in Feb 2026)
- Supports TCP and UDP, optional TLS, register persistence across restarts
- Ships an official multi-arch Docker image (`oitc/modbus-server`) with
  400k+ pulls on Docker Hub
- Includes a Prometheus/OpenTelemetry metrics endpoint for monitoring
  request counts, register access, and errors

**Disclosure:** I'm the author/maintainer of this project.

- Source: https://github.com/cybcon/modbus-server
- Docker image: https://hub.docker.com/r/oitc/modbus-server