### PR TITLE
Add Amenonuboco DNP3 assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Currently, there are **76 protocols** with a total of 414 resources.
 - [Sniffing SCADA](https://www.youtube.com/watch?v=4vPptUmyv4U) - Karl Koscher @ DEF CON 23 Packet Capture Village (2015)
 - [Unraveling SCADA Protocols Using Sulley Fuzzer](https://www.youtube.com/watch?v=UUta_Ord8GI) - Ganesh Devarajan @ DEF CON 15 (2014)
 ### Tools
+- [Amenonuboco DNP3 assets](https://github.com/schutzz/ot-range-amenonuboco/tree/main/protocol-images/dnp3) - Containerized DNP3 outstation and master assets for reproducible OT/ICS range traffic, including integrity polls, Direct Operate commands, and tshark-verified field extraction.
 - [dnp3-simulator](https://github.com/dnp3/dnp3-simulator) - .NET DNP3 simulator with GUI 
 - [FreyrSCADA DNP3](https://github.com/FreyrSCADA/DNP3) - DNP3 Protocol - Outstation Server and Client Master Simulator
 - [gec/dnp3](https://github.com/gec/dnp3) - Open source Distributed Network Protocol


### PR DESCRIPTION
## Summary

Adds one DNP3-specific resource under **DNP3 → Tools**.

[Amenonuboco DNP3 assets](https://github.com/schutzz/ot-range-amenonuboco/tree/main/protocol-images/dnp3) provides containerized DNP3 outstation and master assets for reproducible, isolated OT/ICS range traffic. The documented exchange includes integrity polls, Direct Operate commands, and tshark-verified DNP3 field extraction.

The project is Apache-2.0 licensed and intended for authorized laboratory use.

## Scope

- one README entry only
- links to the merged `main` documentation for the DNP3 assets
- no generated database files are modified, following the contribution guidance for README-based suggestions